### PR TITLE
Use type_name as identifier for `VersionMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Updated
 * To define the version for the current type, use `self` attribute instead of `type = "path to self"`
+* Use the [type_name](https://doc.rust-lang.org/std/intrinsics/fn.type_name.html) of a type as
+  the key to find its version.
 
 ## [0.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Updated
+* To define the version for the current type, use `self` attribute instead of `type = "path to self"`
 
 ## [0.3.0]
 ### Added

--- a/serde-version/Cargo.toml
+++ b/serde-version/Cargo.toml
@@ -19,6 +19,7 @@ travis-ci = { repository = "fredpointzero/serde-version" }
 serde = "^1.0.0"
 failure = "^0.1.0"
 serde_version_derive = { version = "0.3.0", optional = true, path = "../serde_version_derive" }
+type-name = "0.1.0"
 
 [dev-dependencies]
 serde_version_derive = { version = "0.3.0", path = "../serde_version_derive" }

--- a/serde-version/examples/versioned_groups.rs
+++ b/serde-version/examples/versioned_groups.rs
@@ -41,7 +41,7 @@ struct Av2 {
 #[versions(
     v(index = 1, type = "Av1"),
     v(index = 3, type = "Av2"),
-    v(index = 4, type = "A")
+    v(index = 4, self)
 )]
 struct A {
     c: u8,
@@ -75,7 +75,7 @@ struct Bv2 {
 #[versions(
     v(index = 1, type = "Bv1"),
     v(index = 2, type = "Bv2"),
-    v(index = 3, type = "B")
+    v(index = 3, self)
 )]
 struct B {
     cc: u8,

--- a/serde-version/examples/versioned_types.rs
+++ b/serde-version/examples/versioned_types.rs
@@ -33,7 +33,7 @@ struct Av2 {
 #[versions(
     v(index = 1, type = "Av1"),
     v(index = 3, type = "Av2"),
-    v(index = 4, type = "A")
+    v(index = 4, self)
 )]
 struct A {
     c: u8,

--- a/serde-version/src/exports.rs
+++ b/serde-version/src/exports.rs
@@ -1,0 +1,1 @@
+pub use type_name::get as get_type_name;

--- a/serde-version/src/lib.rs
+++ b/serde-version/src/lib.rs
@@ -140,10 +140,10 @@
 //!
 //!   // First get a header
 //!   // Here, we use the version 1 of `A`
-//!   let versions: serde_version::DefaultVersionMap = ron::de::from_str(r#"{ "A": 1 }"#).unwrap();
+//!   // Note: `rust_out` is the module used for the doc script
+//!   let versions: serde_version::DefaultVersionMap = ron::de::from_str(r#"{ "rust_out::A": 1 }"#).unwrap();
 //!   
 //!   // Let's deserialize some values
-//!   
 //!   // Deserialize directly A
 //!   let mut deserializer = ron::de::Deserializer::from_str(r#"A(a: 1)"#).unwrap();
 //!   let value = A::deserialize_versioned(&mut deserializer, &versions).unwrap();
@@ -180,6 +180,7 @@ pub use serde_version_derive::*;
 extern crate failure;
 
 mod deserializer;
+pub mod exports;
 mod seed;
 mod visitor;
 

--- a/serde-version/src/lib.rs
+++ b/serde-version/src/lib.rs
@@ -116,7 +116,7 @@
 //! #   a: u8
 //! # }
 //! # #[derive(Deserialize, DeserializeVersioned, PartialEq, Debug)]
-//! # #[versions(v(index = 1, type = "Av1"), v(index = 2, type = "A"))]
+//! # #[versions(v(index = 1, type = "Av1"), v(index = 2, self))]
 //! # struct A {
 //! #   b: u8
 //! # }

--- a/serde-version/tests/test_de.rs
+++ b/serde-version/tests/test_de.rs
@@ -32,7 +32,7 @@ impl Default for Av2 {
 #[versions(
     v(index = 1, type = "Av1"),
     version(index = 3, type = "Av2", default),
-    v(index = 4, type = "A")
+    v(index = 4, self)
 )]
 struct A {
     c: u8,

--- a/serde-version/tests/test_de.rs
+++ b/serde-version/tests/test_de.rs
@@ -104,11 +104,11 @@ macro_rules! declare_tests_versions {
 }
 
 declare_tests_versions! {
-    test_version ("A" => 1) {
+    test_version ("test_de::A" => 1) {
         "A(a: 8)" => A { c: 8 },
         "ContainsA(a: A(a: 4))" => ContainsA { a: A { c: 4 }},
     }
-    test_current_version ("A" => 4) {
+    test_current_version ("test_de::A" => 4) {
         "A(c: 8)" => A { c: 8 },
         "ContainsA(a: A(c: 4))" => ContainsA { a: A { c: 4 }},
     }
@@ -116,14 +116,14 @@ declare_tests_versions! {
         "A(c: 8)" => A { c: 8 },
         "ContainsA(a: A(c: 4))" => ContainsA { a: A { c: 4 }},
     }
-    test_default_version ("A" => 3) {
+    test_default_version ("test_de::A" => 3) {
         "A(b: 8)" => A { c: 8 },
         "ContainsA(a: A(b: 4))" => ContainsA { a: A { c: 4 }},
         "A()" => A { c: 5 },
         "ContainsA(a: A())" => ContainsA { a: A { c: 5 }},
     }
-    fail test_unknown_version ("A" => 5) {
-        "A(b: 8)" => A: Error::InvalidVersionError(InvalidVersionError { version: 5, type_id: "A".to_owned() }),
-        "ContainsA(a: A(b: 4))" => ContainsA: Error::DeserializeError(Error::DeserializeError(<ron::de::Error as serde::de::Error>::custom("Invalid version 5 for A"))),
+    fail test_unknown_version ("test_de::A" => 5) {
+        "A(b: 8)" => A: Error::InvalidVersionError(InvalidVersionError { version: 5, type_id: "test_de::A".to_owned() }),
+        "ContainsA(a: A(b: 4))" => ContainsA: Error::DeserializeError(Error::DeserializeError(<ron::de::Error as serde::de::Error>::custom("Invalid version 5 for test_de::A"))),
     }
 }

--- a/serde_version_derive/src/de/mod.rs
+++ b/serde_version_derive/src/de/mod.rs
@@ -37,10 +37,7 @@ pub fn expand_derive_deserialize_versioned(
                     .extend(cont_where_clause.predicates.iter().cloned())
             }
 
-            // TODO: Find the deserialization name from the serde attribute
-            //   (like `#[serde(rename(deserialize = "deser_name"))]`
-            let ident_string = ident.to_string();
-            let deser_name = syn::LitStr::new(&ident_string, ident.span());
+            let deser_name = quote! { _serde_version::exports::get_type_name::<Self>() };
 
             let last_version = *versions
                 .iter()


### PR DESCRIPTION
* To define the version for the current type, use `self` attribute instead of `type = "path to self"`
* Use the [type_name](https://doc.rust-lang.org/std/intrinsics/fn.type_name.html) of a type as the key to find its version.